### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Go
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/LiquidCats/graceful/security/code-scanning/1](https://github.com/LiquidCats/graceful/security/code-scanning/1)

To fix the problem, we will add a `permissions` block at the root level of the workflow. This block will specify the least privileges required for the workflow to function correctly. For this particular workflow:
- The `actions/checkout` step requires `contents: read` to fetch the repository code.
- No other permissions appear necessary, as the workflow only runs tests and does not make changes to the repository.

The `permissions` block will be added after the `name` key and before the `on` block to apply the permissions to all jobs in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
