### PR TITLE
FIX: logger pointer

### DIFF
--- a/tiker.go
+++ b/tiker.go
@@ -11,20 +11,21 @@ import (
 var ErrTickerFailure = eris.New("ticker failure")
 
 type ticker struct {
-	logger zerolog.Logger
+	logger *zerolog.Logger
 }
 
 type TickerOpt func(*ticker)
 
-func WithTickerLogger(logger zerolog.Logger) TickerOpt {
+func WithTickerLogger(logger *zerolog.Logger) TickerOpt {
 	return func(t *ticker) {
 		t.logger = logger
 	}
 }
 
-func NewTicker(interval time.Duration, runner Runner, opts ...TickerOpt) Runner {
+func Ticker(interval time.Duration, runner Runner, opts ...TickerOpt) Runner {
+	noop := zerolog.Nop()
 	cfg := &ticker{
-		logger: zerolog.Nop(),
+		logger: &noop,
 	}
 	for _, opt := range opts {
 		opt(cfg)

--- a/tiker_test.go
+++ b/tiker_test.go
@@ -22,7 +22,7 @@ func TestTickerRunsAtInterval(t *testing.T) {
 		atomic.AddInt32(&cnt, 1)
 		return nil
 	}
-	ticker := graceful.NewTicker(interval, runner)
+	ticker := graceful.Ticker(interval, runner)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -44,7 +44,7 @@ func TestTickerRunsAtInterval(t *testing.T) {
 func TestTickerErrTickerFailure(t *testing.T) {
 	interval := 10 * time.Millisecond
 	runner := func(ctx context.Context) error { return graceful.ErrTickerFailure }
-	ticker := graceful.NewTicker(interval, runner)
+	ticker := graceful.Ticker(interval, runner)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
@@ -76,7 +76,7 @@ func TestTickerNonFailureErrorLogged(t *testing.T) {
 	}
 	var buf bytes.Buffer
 	logger := zerolog.New(&buf)
-	ticker := graceful.NewTicker(interval, runner, graceful.WithTickerLogger(logger))
+	ticker := graceful.Ticker(interval, runner, graceful.WithTickerLogger(&logger))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
@@ -101,7 +101,7 @@ func TestTickerNonFailureErrorLogged(t *testing.T) {
 func TestTickerContextCancellation(t *testing.T) {
 	interval := 5 * time.Millisecond
 	runner := func(ctx context.Context) error { return nil }
-	ticker := graceful.NewTicker(interval, runner)
+	ticker := graceful.Ticker(interval, runner)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel immediately
@@ -115,7 +115,7 @@ func TestTickerWithLogger(t *testing.T) {
 	runner := func(ctx context.Context) error { return nil }
 	var buf bytes.Buffer
 	logger := zerolog.New(&buf)
-	ticker := graceful.NewTicker(interval, runner, graceful.WithTickerLogger(logger))
+	ticker := graceful.Ticker(interval, runner, graceful.WithTickerLogger(&logger))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup

--- a/worker.go
+++ b/worker.go
@@ -10,12 +10,12 @@ import (
 var ErrWorkerFailure = eris.New("worker failure")
 
 type worker struct {
-	logger zerolog.Logger
+	logger *zerolog.Logger
 }
 
 type WorkerOpt func(*worker)
 
-func WithWorkerLogger(logger zerolog.Logger) WorkerOpt {
+func WithWorkerLogger(logger *zerolog.Logger) WorkerOpt {
 	return func(w *worker) {
 		w.logger = logger
 	}
@@ -24,8 +24,9 @@ func WithWorkerLogger(logger zerolog.Logger) WorkerOpt {
 type WorkerHandler[T any] func(context.Context, T) error
 
 func Worker[T any](ch <-chan T, runner WorkerHandler[T], opts ...WorkerOpt) Runner {
+	noop := zerolog.Nop()
 	cfg := &worker{
-		logger: zerolog.Nop(),
+		logger: &noop,
 	}
 	for _, opt := range opts {
 		opt(cfg)

--- a/worker_test.go
+++ b/worker_test.go
@@ -89,7 +89,7 @@ func TestOtherError(t *testing.T) {
 		return nil
 	}
 
-	runner := graceful.Worker[int](ch, handler, graceful.WithWorkerLogger(logger))
+	runner := graceful.Worker[int](ch, handler, graceful.WithWorkerLogger(&logger))
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -121,7 +121,7 @@ func TestWithWorkerLogger(t *testing.T) {
 
 	handler := func(ctx context.Context, v int) error { return nil }
 
-	runner := graceful.Worker[int](ch, handler, graceful.WithWorkerLogger(logger))
+	runner := graceful.Worker[int](ch, handler, graceful.WithWorkerLogger(&logger))
 
 	var wg sync.WaitGroup
 	wg.Add(1)


### PR DESCRIPTION
- Switch ticker and worker loggers to *zerolog.Logger
- Rename NewTicker to Ticker and keep API behavior
- Initialize default logger as a *zerolog.Logger (noop)
- Update tests to pass logger pointers to WithTickerLogger/WithWorkerLogger